### PR TITLE
disqus 를 giscus로 마이그레이션

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@docusaurus/preset-classic": "^3.6.3",
     "@docusaurus/theme-live-codeblock": "^3.6.3",
     "@docusaurus/theme-mermaid": "^3.6.3",
+    "@giscus/react": "^3.1.0",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@docusaurus/theme-mermaid": "^3.6.3",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.1",
-    "disqus-react": "^1.1.5",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Giscus from "@giscus/react";
+import { useColorMode } from "@docusaurus/theme-common";
+
+export default function Comments(): JSX.Element {
+  const { colorMode } = useColorMode();
+
+  return (
+    <div>
+      <Giscus
+        id="comments"
+        repo="sewonkimm/sewonkimm.github.io"
+        repoId="MDEwOlJlcG9zaXRvcnkxOTcwOTQ0Mjg="
+        category="Comments"
+        categoryId="DIC_kwDOC79sHM4Cm1Dx"
+        mapping="pathname"
+        strict="0"
+        reactionsEnabled="1"
+        emitMetadata="0"
+        inputPosition="top"
+        theme={colorMode === "dark" ? "dark_tritanopia" : "light_tritanopia"}
+        lang="ko"
+        loading="lazy"
+      />
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -3,6 +3,8 @@ import BlogPostItem from "@theme-original/BlogPostItem";
 import type BlogPostItemType from "@theme/BlogPostItem";
 import type { WrapperProps } from "@docusaurus/types";
 import { useLocation } from "@docusaurus/router";
+import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
+import Comments from "@site/src/components/Comments";
 
 type Props = WrapperProps<typeof BlogPostItemType>;
 
@@ -10,6 +12,11 @@ export default function BlogPostItemWrapper(props: Props): JSX.Element {
   const location = useLocation();
   const { pathname } = location;
   const isNotList = pathname !== "/blog";
+
+  const { metadata } = useBlogPost();
+  const { frontMatter } = metadata as any;
+  const { comments = true } = frontMatter;
+  const showComments = comments && isNotList;
 
   return (
     <>
@@ -21,6 +28,8 @@ export default function BlogPostItemWrapper(props: Props): JSX.Element {
         </div>
       )}
       <BlogPostItem {...props} />
+
+      {showComments && <Comments />}
     </>
   );
 }

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -3,8 +3,6 @@ import BlogPostItem from "@theme-original/BlogPostItem";
 import type BlogPostItemType from "@theme/BlogPostItem";
 import type { WrapperProps } from "@docusaurus/types";
 import { useLocation } from "@docusaurus/router";
-import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
-import { DiscussionEmbed } from "disqus-react";
 
 type Props = WrapperProps<typeof BlogPostItemType>;
 
@@ -12,11 +10,6 @@ export default function BlogPostItemWrapper(props: Props): JSX.Element {
   const location = useLocation();
   const { pathname } = location;
   const isNotList = pathname !== "/blog";
-
-  const { metadata } = useBlogPost();
-  const { frontMatter, slug, title } = metadata as any;
-  const { comments = true } = frontMatter;
-  const showComments = comments && isNotList;
 
   return (
     <>
@@ -27,21 +20,7 @@ export default function BlogPostItemWrapper(props: Props): JSX.Element {
           </a>
         </div>
       )}
-
       <BlogPostItem {...props} />
-
-      <h1>{comments}</h1>
-      {showComments && (
-        <DiscussionEmbed
-          shortname="Insight Nest"
-          config={{
-            url: slug,
-            identifier: slug,
-            title,
-            language: "ko_KR",
-          }}
-        />
-      )}
     </>
   );
 }

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Footer from "@theme-original/DocItem/Footer";
+import type FooterType from "@theme/DocItem/Footer";
+import type { WrapperProps } from "@docusaurus/types";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import Comments from "@site/src/components/Comments";
+
+type Props = WrapperProps<typeof FooterType>;
+
+export default function FooterWrapper(props: Props): JSX.Element {
+  const { metadata } = useDoc();
+  const { comments = true } = metadata.frontMatter;
+
+  return (
+    <>
+      <Footer {...props} />
+      {comments && <Comments />}
+    </>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,13 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
+"@giscus/react@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@giscus/react/-/react-3.1.0.tgz#0ab77cc80d765989e87403ea7f50ba7a790a36c7"
+  integrity sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==
+  dependencies:
+    giscus "^1.6.0"
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -2185,6 +2192,18 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
+
+"@lit-labs/ssr-dom-shim@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz#a28799c463177d1a0b0e5cefdc173da5ac859eb4"
+  integrity sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==
+
+"@lit/reactive-element@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.4.tgz#8f2ed950a848016383894a26180ff06c56ae001b"
+  integrity sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.2.0"
 
 "@mdx-js/mdx@^3.0.0":
   version "3.1.0"
@@ -3252,7 +3271,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/trusted-types@^2.0.7":
+"@types/trusted-types@^2.0.2", "@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
@@ -5670,6 +5689,13 @@ get-stream@^6.0.0, get-stream@^6.0.1:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+giscus@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/giscus/-/giscus-1.6.0.tgz#96c592e01829707b3a0ba72c2636c07a28b5c19d"
+  integrity sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==
+  dependencies:
+    lit "^3.2.1"
+
 github-slugger@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.5.0.tgz#17891bbc73232051474d68bd867a34625c955f7d"
@@ -6750,6 +6776,31 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+lit-element@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.1.1.tgz#07905992815076e388cf6f1faffc7d6866c82007"
+  integrity sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==
+  dependencies:
+    "@lit-labs/ssr-dom-shim" "^1.2.0"
+    "@lit/reactive-element" "^2.0.4"
+    lit-html "^3.2.0"
+
+lit-html@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.2.1.tgz#8fc49e3531ee5947e4d93e8a5aa642ab1649833b"
+  integrity sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.2.1.tgz#d6dd15eac20db3a098e81e2c85f70a751ff55592"
+  integrity sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==
+  dependencies:
+    "@lit/reactive-element" "^2.0.4"
+    lit-element "^4.1.0"
+    lit-html "^3.2.0"
 
 loader-runner@^4.2.0:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,11 +4982,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-disqus-react@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/disqus-react/-/disqus-react-1.1.5.tgz#e844d040eed8f55467106e49d00e29d629e07043"
-  integrity sha512-9fdG5m6c3wJzlCDLaMheuUagMVj3s5qgUSXdekpCsvzYOKG21AiuOoqyDzA0oXrpPnYzgpnsvPYqZ+i0hJPGZw==
-
 dns-packet@^5.2.2:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.6.1.tgz#ae888ad425a9d1478a0674256ab866de1012cf2f"


### PR DESCRIPTION
[참고](https://rikublock.dev/docs/tutorials/giscus-integration/)

https://giscus.app/ko

특징: GitHub Discussions를 기반으로 댓글 기능을 제공
장점:
무료 사용 가능 (GitHub Discussions 이용)
Docusaurus와 공식적으로 호환됨
Markdown 및 코드 블록 지원
스팸 관리 불필요 (GitHub 계정 필요)